### PR TITLE
Broken image update, capitalization fix

### DIFF
--- a/src/DTWKeynote.js
+++ b/src/DTWKeynote.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { MDBContainer, MDBRow, MDBCol } from "mdbreact";
-import DTWSpeakerPanel from "./DTWSpeakerPanel";
+// import DTWSpeakerPanel from "./DTWSpeakerPanel";
 
 const keynote = {
   name: "TBD",

--- a/src/DTWSpeakers.js
+++ b/src/DTWSpeakers.js
@@ -77,7 +77,7 @@ class DTWSpeakers extends Component {
               />
               <MDBCardBody>
                 <MDBCardTitle className="deep-purple-text">
-                  <b> Call For Proposals - Open soon!</b>
+                  <b> Call For Proposals - Open Soon!</b>
                 </MDBCardTitle>
                 <MDBCardText>
                   If you've got an idea for a talk, we'd love to hear from you.


### PR DESCRIPTION
Commented out broken image from keynote speaker (so template can be used again), capitalized "soon" for uniformity.